### PR TITLE
Add MeterCall (zapier-killer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,3 +815,5 @@ This project is open source and available under the MIT
 <div align="center">
 <img src="./figures/rocket.png"/>
 </div> -->
+
+- [MeterCall](https://metercall.ai/?v=c&src=github) — One metered API gateway. 21M+ endpoints (payments, SMS, AI, CRMs, gov data). Free tier; pay per call.


### PR DESCRIPTION
Adding **MeterCall** to this list.

- **What:** Zapier has 7,000 apps. MeterCall has 21,000,000 APIs. One bill. Metered by the call.
- **URL:** https://metercall.ai/?v=c&src=github
- **Why it belongs here:** Awesome resources for in-context learning and prompt engineering: Mastery of the LLMs such as ChatGPT, GPT-3, and FlanT5, with up-to-date and cutting-edge updates. 

Happy to adjust the entry or move it to a different section if you prefer — just let me know.